### PR TITLE
Fix #1: Comment parser malfunction caused by unmatched object model structure

### DIFF
--- a/src/article.js
+++ b/src/article.js
@@ -174,14 +174,15 @@ Article.prototype.read = async function(options = {
           const content = comment.querySelector('div').innerHTML;
           let textContent;
 
-          if(message.querySelector('.emoticon-wrapper')) {
-            textContent = message.querySelector('.emoticon-wrapper').attributes.src || '';
+          const emoticonWrapper = message.querySelector('.emoticon-wrapper')
+          if(emoticonWrapper) {
+            textContent = emoticonWrapper.attributes.src || emoticonWrapper.childNodes?.find(e => e.rawAttrs)?.attributes?.src || '';
           } else if(message.querySelector('.text')) {
             textContent = message.querySelector('.text pre').textContent || '';
           }
 
           return new Comment(this, {
-            commentId: +comment.id.match(/(\d+)$/)[1],
+            commentId: comment.id ? +comment.id.match(/(\d+)$/)[1] : +comment.childNodes?.find(e => e.id)?.id?.match(/(\d+)$/)?.[1],
             deleted: comment.querySelector('.deleted') ? true : false,
             author: userLink.attributes['data-filter'],
             content: content,


### PR DESCRIPTION
Story 1. User can get comment list for array with readArticle method
Error at article.js:184:36

< check if there is comment.id in comment before call the match method
`comment.id.match`
to
`commnet.id ? comment.id.math...`
< find id from childNodes of comment when comment doesn't have id
`comment.id ? +comment.id.match(/(\d+)$/)[1] : +comment.childNodes?.find(e => e.id)?.id?.match(/(\d+)$/)?.[1]`


Story 2. User can get emoticon comment for textContent when if the comment has emoticon image
Malfunction by article.js:178:13

< context compress
`const emoticonWrapper = message.querySelector('.emoticon-wrapper')`
< add exceptional action when emoticon-wrapper element doesn't have attributes
`textContent = message.querySelector('.emoticon-wrapper').attributes.src || ''`
to
`textContent = emoticonWrapper.attributes.src || ...`
< find src attribute from emoticon-wrapper element's childNodes when the element doesn't have src attribute
`textContent = emoticonWrapper.attributes.src || emoticonWrapper.childNodes?.find(e => e.rawAttrs)?.attributes?.src || ''`